### PR TITLE
Improve generated code, minor fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/enum-display"
 homepage = "https://github.com/SeedyROM/enum-display"
-repository = "https://github.com/SeedyROM/repository"
+repository = "https://github.com/SeedyROM/enum-display"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/enum-display-macro/src/lib.rs
+++ b/enum-display-macro/src/lib.rs
@@ -71,23 +71,31 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
         match variant.fields {
             syn::Fields::Named(_) => quote! {
-                #ident { .. } => write!(f, #ident_str),
+                #ident { .. } => #ident_str,
             },
             syn::Fields::Unnamed(_) => quote! {
-                #ident(..) => write!(f, #ident_str),
+                #ident(..) => #ident_str,
             },
             syn::Fields::Unit => quote! {
-                #ident => write!(f, #ident_str),
+                #ident => #ident_str,
             },
         }
     });
 
+    // #[allow(unused_qualifications)] is needed
+    // due to https://github.com/SeedyROM/enum-display/issues/1
+    // Possibly related to https://github.com/rust-lang/rust/issues/96698
     let output = quote! {
-        impl std::fmt::Display for #ident {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                match self {
-                    #(#ident::#variants)*
-                }
+        #[automatically_derived]
+        #[allow(unused_qualifications)]
+        impl ::core::fmt::Display for #ident {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                ::core::fmt::Formatter::write_str(
+                    f,
+                    match self {
+                        #(#ident::#variants)*
+                    },
+                )
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,49 +69,52 @@ mod tests {
 
     #[test]
     fn test_unit_field_variant() {
-        assert!(TestEnum::Name.to_string() == "Name");
+        assert_eq!(TestEnum::Name.to_string(), "Name");
     }
 
     #[test]
     fn test_named_fields_variant() {
-        assert!(
+        assert_eq!(
             TestEnum::Address {
                 street: "123 Main St".to_string(),
                 city: "Any Town".to_string(),
                 state: "CA".to_string(),
                 zip: "12345".to_string()
             }
-            .to_string()
-                == "Address"
+            .to_string(),
+            "Address"
         );
     }
 
     #[test]
     fn test_unnamed_fields_variant() {
-        assert!(TestEnum::DateOfBirth(1, 1, 2000).to_string() == "DateOfBirth");
+        assert_eq!(TestEnum::DateOfBirth(1, 1, 2000).to_string(), "DateOfBirth");
     }
 
     #[test]
     fn test_unit_field_variant_case_transform() {
-        assert!(TestEnumWithAttribute::Name.to_string() == "name");
+        assert_eq!(TestEnumWithAttribute::Name.to_string(), "name");
     }
 
     #[test]
     fn test_named_fields_variant_case_transform() {
-        assert!(
+        assert_eq!(
             TestEnumWithAttribute::Address {
                 street: "123 Main St".to_string(),
                 city: "Any Town".to_string(),
                 state: "CA".to_string(),
                 zip: "12345".to_string()
             }
-            .to_string()
-                == "address"
+            .to_string(),
+            "address"
         );
     }
 
     #[test]
     fn test_unnamed_fields_variant_case_transform() {
-        assert!(TestEnumWithAttribute::DateOfBirth(1, 1, 2000).to_string() == "date-of-birth");
+        assert_eq!(
+            TestEnumWithAttribute::DateOfBirth(1, 1, 2000).to_string(),
+            "date-of-birth"
+        );
     }
 }


### PR DESCRIPTION
* Make the output similar to `#[derive(Debug)]`
* Avoid using format macros, and use `write_str` instead
* Fully-qualify all macro types
* Use `::core` instead of `::std`
* Explicitly allow `unused_qualifications`
* Fix URL to the repository
* Use `assert_eq!` instead of `assert!`

Fixes #1