### PR TITLE
[FEATURE]: Generics, lifetimes, where clauses and internal field variant formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "enum-display"
 description = "A macro to derive Display for enums"
 keywords = ["enum", "display", "derive", "macro"]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/enum-display"
@@ -12,4 +12,4 @@ repository = "https://github.com/SeedyROM/enum-display"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-enum-display-macro = { version = "0.1.4" }
+enum-display-macro = { version = "0.1.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "enum-display-macro"]
+
 [package]
 name = "enum-display"
 description = "A macro to derive Display for enums"
@@ -9,7 +12,5 @@ documentation = "https://docs.rs/enum-display"
 homepage = "https://github.com/SeedyROM/enum-display"
 repository = "https://github.com/SeedyROM/enum-display"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-enum-display-macro = { version = "0.1.5" }
+enum-display-macro = { path = "./enum-display-macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ homepage = "https://github.com/SeedyROM/enum-display"
 repository = "https://github.com/SeedyROM/enum-display"
 
 [dependencies]
-enum-display-macro = { path = "./enum-display-macro" }
+enum-display-macro = { version = "0.1.5", path = "./enum-display-macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,18 @@ repository = "https://github.com/SeedyROM/enum-display"
 
 [dependencies]
 enum-display-macro = { version = "0.1.5", path = "./enum-display-macro" }
+
+[features]
+default = ["std"]
+std = []
+
+[dev-dependencies]
+static_assertions = "1.1"
+
+[[test]]
+name = "no_std_integration"
+required-features = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/enum-display-macro/Cargo.toml
+++ b/enum-display-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "enum-display-macro"
 description = "A macro to derive Display for enums"
 keywords = ["enum", "display", "derive", "macro"]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/enum-display/tree/main/enum-display-derive"

--- a/enum-display-macro/Cargo.toml
+++ b/enum-display-macro/Cargo.toml
@@ -12,9 +12,11 @@ repository = "https://github.com/SeedyROM/enum-display/tree/main/enum-display-de
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+proc-macro2 = "1.0.95"
 convert_case = "0.6.0"
 quote = "1.0.21"
 syn = { version = "1.0.101", features = ["full"] }
+regex = "1.11.1"
 
 [lib]
 proc-macro = true

--- a/enum-display-macro/src/lib.rs
+++ b/enum-display-macro/src/lib.rs
@@ -54,7 +54,7 @@ impl EnumAttrs {
             "Flat" => Case::Flat,
             "UpperFlat" => Case::UpperFlat,
             "Alternating" => Case::Alternating,
-            _ => panic!("Unrecognized case name: {}", case_name),
+            _ => panic!("Unrecognized case name: {case_name}"),
         }
     }
 
@@ -105,7 +105,7 @@ impl VariantAttrs {
         re.replace_all(fmt, |caps: &regex::Captures| {
             let idx = &caps[1];
             let fmt_spec = &caps[2];
-            format!("{{_unnamed_{}{} }}", idx, fmt_spec)
+            format!("{{_unnamed_{idx}{fmt_spec}}}")
         })
         .to_string()
     }
@@ -134,7 +134,7 @@ impl NamedVariantIR {
         Self { info, fields }
     }
 
-    fn genereate(self, any_has_format: bool) -> proc_macro2::TokenStream {
+    fn generate(self, any_has_format: bool) -> proc_macro2::TokenStream {
         let VariantInfo {
             ident,
             ident_transformed,

--- a/enum-display-macro/src/lib.rs
+++ b/enum-display-macro/src/lib.rs
@@ -1,89 +1,312 @@
+use std::{collections::HashSet, fmt::format};
+
 use convert_case::{Case, Casing};
 use proc_macro::{self, TokenStream};
+use proc_macro2::Span;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use regex::Regex;
+use syn::{parse_macro_input, Attribute, DeriveInput, FieldsNamed, FieldsUnnamed, Ident, Variant};
 
-fn parse_case_name(case_name: &str) -> Case {
-    match case_name {
-        "Upper" => Case::Upper,
-        "Lower" => Case::Lower,
-        "Title" => Case::Title,
-        "Toggle" => Case::Toggle,
-        "Camel" => Case::Camel,
-        "Pascal" => Case::Pascal,
-        "UpperCamel" => Case::UpperCamel,
-        "Snake" => Case::Snake,
-        "UpperSnake" => Case::UpperSnake,
-        "ScreamingSnake" => Case::ScreamingSnake,
-        "Kebab" => Case::Kebab,
-        "Cobol" => Case::Cobol,
-        "UpperKebab" => Case::UpperKebab,
-        "Train" => Case::Train,
-        "Flat" => Case::Flat,
-        "UpperFlat" => Case::UpperFlat,
-        "Alternating" => Case::Alternating,
-        _ => panic!("Unrecognized case name: {}", case_name),
-    }
+// Enum attributes
+struct EnumAttrs {
+    case_transform: Option<Case>,
 }
 
-#[proc_macro_derive(EnumDisplay, attributes(enum_display))]
-pub fn derive(input: TokenStream) -> TokenStream {
-    // Parse the input tokens into a syntax tree
-    let DeriveInput {
-        ident, data, attrs, generics, ..
-    } = parse_macro_input!(input);
+impl EnumAttrs {
+    fn from_attrs(attrs: Vec<Attribute>) -> Self {
+        let mut case_transform: Option<Case> = None;
 
-    // Should we transform the case of the enum variants?
-    let mut case_transform: Option<Case> = None;
-
-    // Find the enum_display attribute
-    for attr in attrs.into_iter() {
-        if attr.path.is_ident("enum_display") {
-            let meta = attr.parse_meta().unwrap();
-            if let syn::Meta::List(list) = meta {
-                for nested in list.nested {
-                    if let syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) = nested {
-                        if name_value.path.is_ident("case") {
-                            if let syn::Lit::Str(lit_str) = name_value.lit {
-                                // Set the case transform
-                                case_transform = Some(parse_case_name(lit_str.value().as_str()));
+        for attr in attrs.into_iter() {
+            if attr.path.is_ident("enum_display") {
+                let meta = attr.parse_meta().unwrap();
+                if let syn::Meta::List(list) = meta {
+                    for nested in list.nested {
+                        if let syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) = nested {
+                            if name_value.path.is_ident("case") {
+                                if let syn::Lit::Str(lit_str) = name_value.lit {
+                                    case_transform =
+                                        Some(Self::parse_case_name(lit_str.value().as_str()));
+                                }
                             }
                         }
                     }
                 }
             }
         }
+
+        Self { case_transform }
     }
 
-    // Build the match arms
-    let variants = match data {
+    fn parse_case_name(case_name: &str) -> Case {
+        match case_name {
+            "Upper" => Case::Upper,
+            "Lower" => Case::Lower,
+            "Title" => Case::Title,
+            "Toggle" => Case::Toggle,
+            "Camel" => Case::Camel,
+            "Pascal" => Case::Pascal,
+            "UpperCamel" => Case::UpperCamel,
+            "Snake" => Case::Snake,
+            "UpperSnake" => Case::UpperSnake,
+            "ScreamingSnake" => Case::ScreamingSnake,
+            "Kebab" => Case::Kebab,
+            "Cobol" => Case::Cobol,
+            "UpperKebab" => Case::UpperKebab,
+            "Train" => Case::Train,
+            "Flat" => Case::Flat,
+            "UpperFlat" => Case::UpperFlat,
+            "Alternating" => Case::Alternating,
+            _ => panic!("Unrecognized case name: {}", case_name),
+        }
+    }
+
+    fn transform_case(&self, ident: String) -> String {
+        if let Some(case) = self.case_transform {
+            ident.to_case(case)
+        } else {
+            ident
+        }
+    }
+}
+
+// Variant attributes
+struct VariantAttrs {
+    format: Option<String>,
+}
+
+impl VariantAttrs {
+    fn from_attrs(attrs: Vec<Attribute>) -> Self {
+        let mut format = None;
+
+        // Find the variant_display attribute
+        for attr in attrs.into_iter() {
+            if attr.path.is_ident("variant_display") {
+                let meta = attr.parse_meta().unwrap();
+                if let syn::Meta::List(list) = meta {
+                    for nested in list.nested {
+                        if let syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) = nested {
+                            if name_value.path.is_ident("format") {
+                                if let syn::Lit::Str(lit_str) = name_value.lit {
+                                    format = Some(Self::translate_numeric_placeholders(&lit_str.value()));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Self { format }
+    }
+
+    // Translates {123:?} to {_unnamed_123:?} for safer format arg usage
+    fn translate_numeric_placeholders(fmt: &str) -> String {
+        let re = Regex::new(r"\{\s*(\d+)\s*([^}]*)\}").unwrap();
+        re.replace_all(fmt, |caps: &regex::Captures| {
+            let idx = &caps[1];
+            let fmt_spec = &caps[2];
+            format!("{{_unnamed_{}{} }}", idx, fmt_spec)
+        })
+        .to_string()
+    }
+
+    // Makes a hash set of user referenced format args so we can output minimal generated code
+    fn read_named_placeholders(&self) -> HashSet<&str> {
+        if let Some(fmt) = &self.format {
+            let re = Regex::new(r"\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*[^}]*\}").unwrap();
+            re.captures_iter(&fmt)
+                .filter_map(|caps| caps.get(1).map(|m| m.as_str()))
+                .collect()
+        } else {
+            HashSet::new()
+        }
+    }
+}
+
+// Shared intermediate variant info
+struct VariantInfo {
+    ident: Ident,
+    ident_transformed: String,
+    attrs: VariantAttrs,
+}
+
+// Intermediate Named variant info
+struct NamedVariantIR {
+    info: VariantInfo,
+    fields: Vec<Ident>,
+}
+
+impl NamedVariantIR {
+    fn from_fields_named(fields_named: FieldsNamed, info: VariantInfo) -> Self {
+        let referenced_fields = info.attrs.read_named_placeholders();
+        if referenced_fields.is_empty() {
+            Self { info, fields: Vec::new() }
+        } else {
+            let fields = fields_named
+                .named
+                .into_iter()
+                .filter_map(|field| {
+                    let ident = field.ident.unwrap();
+                    referenced_fields
+                        .contains(ident.to_string().as_str())
+                        .then_some(ident)
+                })
+                .collect();
+            Self { info, fields }
+        }
+    }
+
+    fn gen(self, any_has_format: bool) -> proc_macro2::TokenStream {
+        let VariantInfo { ident, ident_transformed, attrs } = self.info;
+        let fields = self.fields;
+        match (any_has_format, attrs.format) {
+            (true, Some(fmt)) => quote! { #ident { #(#fields),*, .. } => { let variant = #ident_transformed; format!(#fmt) } },
+            (true, None) => quote! { #ident { .. } => String::from(#ident_transformed), },
+            (false, None) => quote! { #ident { .. } => #ident_transformed, },
+            _ => unreachable!("`any_has_format` should never be false when a variant has format string"),
+        }
+    }
+}
+
+// Intermediate Unnamed variant info
+struct UnnamedVariantIR {
+    info: VariantInfo,
+    fields: Vec<Ident>,
+}
+
+impl UnnamedVariantIR {
+    fn from_fields_unnamed(fields_unnamed: FieldsUnnamed, info: VariantInfo) -> Self {
+        let referenced_fields = info.attrs.read_named_placeholders();
+        if referenced_fields.is_empty() {
+            Self { info, fields: Vec::new() }
+        } else {
+            let skip_field = "_";
+            let fields: Vec<Ident> = fields_unnamed
+                .unnamed
+                .into_iter()
+                .enumerate()
+                .map(|(i, _)| {
+                    Ident::new(
+                        referenced_fields
+                            .get(format!("_unnamed_{i}").as_str())
+                            .unwrap_or(&skip_field),
+                        Span::call_site(),
+                    )
+                })
+                .collect();
+            Self { info, fields }
+        }
+    }
+
+    fn gen(self, any_has_format: bool) -> proc_macro2::TokenStream {
+        let VariantInfo { ident, ident_transformed, attrs } = self.info;
+        let fields = self.fields;
+        match (any_has_format, attrs.format) {
+            (true, Some(fmt)) => quote! { #ident(#(#fields),*) => { let variant = #ident_transformed; format!(#fmt) } },
+            (true, None) => quote! { #ident(..) => String::from(#ident_transformed), },
+            (false, None) => quote! { #ident(..) => #ident_transformed, },
+            _ => unreachable!("`any_has_format` should never be false when a variant has format string"),
+        }
+    }
+}
+
+// Intermediate Unit variant info
+struct UnitVariantIR {
+    info: VariantInfo,
+}
+
+impl UnitVariantIR {
+    fn new(info: VariantInfo) -> Self {
+        Self { info }
+    }
+
+    fn gen(self, any_has_format: bool) -> proc_macro2::TokenStream {
+        let VariantInfo { ident, ident_transformed, attrs } = self.info;
+        match (any_has_format, attrs.format) {
+            (true, Some(fmt)) => quote! { #ident => { let variant = #ident_transformed; format!(#fmt) } },
+            (true, None) => quote! { #ident => String::from(#ident_transformed), },
+            (false, None) => quote! { #ident => #ident_transformed, },
+            _ => unreachable!("`any_has_format` should never be false when a variant has format string"),
+        }
+    }
+}
+
+// Intermediate version of Variant
+enum VariantIR {
+    Named(NamedVariantIR),
+    Unnamed(UnnamedVariantIR),
+    Unit(UnitVariantIR),
+}
+
+impl VariantIR {
+    fn from_variant(variant: Variant, enum_attrs: &EnumAttrs) -> Self {
+        let ident_str = variant.ident.to_string();
+        let info = VariantInfo {
+            ident: variant.ident,
+            ident_transformed: enum_attrs.transform_case(ident_str),
+            attrs: VariantAttrs::from_attrs(variant.attrs),
+        };
+        match variant.fields {
+            syn::Fields::Named(fields_named) => {
+                Self::Named(NamedVariantIR::from_fields_named(fields_named, info))
+            },
+            syn::Fields::Unnamed(fields_unnamed) => {
+                Self::Unnamed(UnnamedVariantIR::from_fields_unnamed(fields_unnamed, info))
+            },
+            syn::Fields::Unit => Self::Unit(UnitVariantIR::new(info)),
+        }
+    }
+
+    fn gen(self, any_has_format: bool) -> proc_macro2::TokenStream {
+        match self {
+            VariantIR::Named(named_variant) => named_variant.gen(any_has_format),
+            VariantIR::Unnamed(unnamed_variant) => unnamed_variant.gen(any_has_format),
+            VariantIR::Unit(unit_variant) => unit_variant.gen(any_has_format),
+        }
+    }
+
+    fn has_format(&self) -> bool {
+        match self {
+            VariantIR::Named(named_variant) => &named_variant.info,
+            VariantIR::Unnamed(unnamed_variant) => &unnamed_variant.info,
+            VariantIR::Unit(unit_variant) => &unit_variant.info,
+        }.attrs.format.is_some()
+    }
+}
+
+#[proc_macro_derive(EnumDisplay, attributes(enum_display, variant_display))]
+pub fn derive(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let DeriveInput {
+        ident,
+        data,
+        attrs,
+        generics,
+        ..
+    } = parse_macro_input!(input);
+
+    // Copy generics and bounds
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    // Read enum attrs
+    let enum_attrs = EnumAttrs::from_attrs(attrs);
+
+    // Read variants and variant attrs into an intermediate format
+    let intermediate_variants: Vec<VariantIR> = match data {
         syn::Data::Enum(syn::DataEnum { variants, .. }) => variants,
         _ => panic!("EnumDisplay can only be derived for enums"),
     }
     .into_iter()
-    .map(|variant| {
-        let ident = variant.ident;
-        let ident_str = if case_transform.is_some() {
-            ident.to_string().to_case(case_transform.unwrap())
-        } else {
-            ident.to_string()
-        };
+    .map(|variant| VariantIR::from_variant(variant, &enum_attrs))
+    .collect();
 
-        match variant.fields {
-            syn::Fields::Named(_) => quote! {
-                #ident { .. } => #ident_str,
-            },
-            syn::Fields::Unnamed(_) => quote! {
-                #ident(..) => #ident_str,
-            },
-            syn::Fields::Unit => quote! {
-                #ident => #ident_str,
-            },
-        }
-    });
+    // If any variants have a format string, the output of all match arms must be String instead of &str
+    // This is because we can't return a reference to the temporary output of format!()
+    let any_has_format = intermediate_variants.iter().any(|v| v.has_format());
+    let post_fix = if any_has_format { quote!{ .as_str() } } else { quote! { } };
 
-    // Copy generics and bounds
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    // Build the match arms
+    let variants = intermediate_variants.into_iter().map(|v| v.gen(any_has_format));
 
     // #[allow(unused_qualifications)] is needed
     // due to https://github.com/SeedyROM/enum-display/issues/1
@@ -96,8 +319,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
                 ::core::fmt::Formatter::write_str(
                     f,
                     match self {
-                        #(#ident::#variants)*
-                    },
+                        #(Self::#variants)*
+                    }#post_fix
                 )
             }
         }

--- a/enum-display-macro/src/lib.rs
+++ b/enum-display-macro/src/lib.rs
@@ -30,7 +30,7 @@ fn parse_case_name(case_name: &str) -> Case {
 pub fn derive(input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
     let DeriveInput {
-        ident, data, attrs, ..
+        ident, data, attrs, generics, ..
     } = parse_macro_input!(input);
 
     // Should we transform the case of the enum variants?
@@ -82,13 +82,16 @@ pub fn derive(input: TokenStream) -> TokenStream {
         }
     });
 
+    // Copy generics and bounds
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
     // #[allow(unused_qualifications)] is needed
     // due to https://github.com/SeedyROM/enum-display/issues/1
     // Possibly related to https://github.com/rust-lang/rust/issues/96698
     let output = quote! {
         #[automatically_derived]
         #[allow(unused_qualifications)]
-        impl ::core::fmt::Display for #ident {
+        impl #impl_generics ::core::fmt::Display for #ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 ::core::fmt::Formatter::write_str(
                     f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ mod tests {
 
     #[allow(dead_code)]
     #[derive(EnumDisplay)]
-    enum TestEnumWithGenerics<'a, T: Clone>
+    enum TestEnumWithLifetimeAndGenerics<'a, T: Clone>
     where
         T: std::fmt::Display,
     {
@@ -195,14 +195,17 @@ mod tests {
     }
 
     #[test]
-    fn test_unit_field_variant_with_generics() {
-        assert_eq!(TestEnumWithGenerics::<'_, String>::Name.to_string(), "Name");
+    fn test_unit_field_variant_with_lifetime_and_generics() {
+        assert_eq!(
+            TestEnumWithLifetimeAndGenerics::<'_, String>::Name.to_string(),
+            "Name"
+        );
     }
 
     #[test]
-    fn test_named_fields_variant_with_generics() {
+    fn test_named_fields_variant_with_lifetime_and_generics() {
         assert_eq!(
-            TestEnumWithGenerics::Address {
+            TestEnumWithLifetimeAndGenerics::Address {
                 street: &"123 Main St".to_string(),
                 city: &"Any Town".to_string(),
                 state: &"CA".to_string(),
@@ -214,9 +217,9 @@ mod tests {
     }
 
     #[test]
-    fn test_unnamed_fields_variant_with_generics() {
+    fn test_unnamed_fields_variant_with_lifetime_and_generics() {
         assert_eq!(
-            TestEnumWithGenerics::<'_, String>::DateOfBirth(1, 1, 2000).to_string(),
+            TestEnumWithLifetimeAndGenerics::<'_, String>::DateOfBirth(1, 1, 2000).to_string(),
             "DateOfBirth"
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,19 @@ mod tests {
         DateOfBirth(u32, u32, u32),
     }
 
+    #[allow(dead_code)]
+    #[derive(EnumDisplay)]
+    enum TestEnumWithGenerics<'a, T: Clone> where T: std::fmt::Display {
+        Name,
+        Address {
+            street: &'a T,
+            city: &'a T,
+            state: &'a T,
+            zip: &'a T,
+        },
+        DateOfBirth(u32, u32, u32),
+    }
+
     #[test]
     fn test_unit_field_variant() {
         assert_eq!(TestEnum::Name.to_string(), "Name");
@@ -116,5 +129,29 @@ mod tests {
             TestEnumWithAttribute::DateOfBirth(1, 1, 2000).to_string(),
             "date-of-birth"
         );
+    }
+
+    #[test]
+    fn test_unit_field_variant_with_generics() {
+        assert_eq!(TestEnumWithGenerics::<'_, String>::Name.to_string(), "Name");
+    }
+
+    #[test]
+    fn test_named_fields_variant_with_generics() {
+        assert_eq!(
+            TestEnumWithGenerics::Address {
+                street: &"123 Main St".to_string(),
+                city: &"Any Town".to_string(),
+                state: &"CA".to_string(),
+                zip: &"12345".to_string()
+            }
+            .to_string(),
+            "Address"
+        );
+    }
+
+    #[test]
+    fn test_unnamed_fields_variant_with_generics() {
+        assert_eq!(TestEnumWithGenerics::<'_, String>::DateOfBirth(1, 1, 2000).to_string(), "DateOfBirth");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,42 @@
 //! }
 //!
 //! assert_eq!(Message::HelloGreeting { name: "Alice".to_string() }.to_string(), "hello-greeting");
+//! ```
 //!
-
+//! # Example With Custom Formatting
+//!
+//! Display output can be customised with a format string passed to the `display` enum
+//! variant attribute.
+//!
+//! The case converted variant name is available via the `variant` named parameter.
+//!
+//! Additional parameters available to the format string depend on the type of enum variant:
+//!
+//! | Variant Type     | Format String Field Access                                                        | Example                             |
+//! |------------------|-----------------------------------------------------------------------------------|-------------------------------------|
+//! | Named            | [Named Parameters](https://doc.rust-lang.org/std/fmt/#named-parameters)           | `"{variant} name field is: {name}"` |
+//! | Unnamed (tuple)  | [Positional Parameters](https://doc.rust-lang.org/std/fmt/#positional-parameters) | `"{variant} age field is: {0}"`     |
+//! | Unit             | No additional fields available                                                    | `"{variant} has no fields"`         |
+//!
+//! ```rust
+//! use enum_display::EnumDisplay;
+//!
+//! #[derive(EnumDisplay)]
+//! enum Message {
+//!     #[display("{variant} {name}!")]
+//!     Hello { name: String },
+//!
+//!     #[display("{variant}? {0}")]
+//!     HowOld(usize),
+//!
+//!     #[display("{variant}!")]
+//!     Wow,
+//! }
+//!
+//! assert_eq!(Message::Hello { name: "Alice".to_string() }.to_string(), "Hello Alice!");
+//! assert_eq!(Message::HowOld(123).to_string(), "HowOld? 123");
+//! assert_eq!(Message::Wow.to_string(), "Wow!");
+//! ```
 pub use enum_display_macro::*;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,40 @@ mod tests {
     #[derive(EnumDisplay)]
     enum TestEnum {
         Name,
+
+        #[variant_display(format = "Unit: {variant}")]
+        NameFullFormat,
+
         Address {
             street: String,
             city: String,
             state: String,
             zip: String,
         },
+
+        #[variant_display(format = "Named: {variant} {{{street}, {zip}}}")]
+        AddressPartialFormat {
+            street: String,
+            city: String,
+            state: String,
+            zip: String,
+        },
+
+        #[variant_display(format = "Named: {variant} {{{street}, {city}, {state}, {zip}}}")]
+        AddressFullFormat {
+            street: String,
+            city: String,
+            state: String,
+            zip: String,
+        },
+
         DateOfBirth(u32, u32, u32),
+
+        #[variant_display(format = "Unnamed: {variant}({2})")]
+        DateOfBirthPartialFormat(u32, u32, u32),
+
+        #[variant_display(format = "Unnamed: {variant}({0}, {1}, {2})")]
+        DateOfBirthFullFormat(u32, u32, u32),
     }
 
     #[allow(dead_code)]
@@ -83,6 +110,7 @@ mod tests {
     #[test]
     fn test_unit_field_variant() {
         assert_eq!(TestEnum::Name.to_string(), "Name");
+        assert_eq!(TestEnum::NameFullFormat.to_string(), "Unit: NameFullFormat");
     }
 
     #[test]
@@ -97,11 +125,33 @@ mod tests {
             .to_string(),
             "Address"
         );
+        assert_eq!(
+            TestEnum::AddressPartialFormat {
+                street: "123 Main St".to_string(),
+                city: "Any Town".to_string(),
+                state: "CA".to_string(),
+                zip: "12345".to_string()
+            }
+            .to_string(),
+            "Named: AddressPartialFormat {123 Main St, 12345}"
+        );
+        assert_eq!(
+            TestEnum::AddressFullFormat {
+                street: "123 Main St".to_string(),
+                city: "Any Town".to_string(),
+                state: "CA".to_string(),
+                zip: "12345".to_string()
+            }
+            .to_string(),
+            "Named: AddressFullFormat {123 Main St, Any Town, CA, 12345}"
+        );
     }
 
     #[test]
     fn test_unnamed_fields_variant() {
-        assert_eq!(TestEnum::DateOfBirth(1, 1, 2000).to_string(), "DateOfBirth");
+        assert_eq!(TestEnum::DateOfBirth(1, 2, 1999).to_string(), "DateOfBirth");
+        assert_eq!(TestEnum::DateOfBirthPartialFormat(1, 2, 1999).to_string(), "Unnamed: DateOfBirthPartialFormat(1999)");
+        assert_eq!(TestEnum::DateOfBirthFullFormat(1, 2, 1999).to_string(), "Unnamed: DateOfBirthFullFormat(1, 2, 1999)");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,10 @@ mod tests {
     enum TestEnum {
         Name,
 
-        #[variant_display(format = "Unit: {variant}")]
+        #[display(format = "Overridden Name")]
+        OverrideName,
+
+        #[display(format = "Unit: {variant}")]
         NameFullFormat,
 
         Address {
@@ -55,7 +58,7 @@ mod tests {
             zip: String,
         },
 
-        #[variant_display(format = "Named: {variant} {{{street}, {zip}}}")]
+        #[display(format = "Named: {variant} {{{street}, {zip}}}")]
         AddressPartialFormat {
             street: String,
             city: String,
@@ -63,7 +66,7 @@ mod tests {
             zip: String,
         },
 
-        #[variant_display(format = "Named: {variant} {{{street}, {city}, {state}, {zip}}}")]
+        #[display(format = "Named: {variant} {{{street}, {city}, {state}, {zip}}}")]
         AddressFullFormat {
             street: String,
             city: String,
@@ -73,10 +76,10 @@ mod tests {
 
         DateOfBirth(u32, u32, u32),
 
-        #[variant_display(format = "Unnamed: {variant}({2})")]
+        #[display(format = "Unnamed: {variant}({2})")]
         DateOfBirthPartialFormat(u32, u32, u32),
 
-        #[variant_display(format = "Unnamed: {variant}({0}, {1}, {2})")]
+        #[display(format = "Unnamed: {variant}({0}, {1}, {2})")]
         DateOfBirthFullFormat(u32, u32, u32),
     }
 
@@ -113,6 +116,7 @@ mod tests {
     #[test]
     fn test_unit_field_variant() {
         assert_eq!(TestEnum::Name.to_string(), "Name");
+        assert_eq!(TestEnum::OverrideName.to_string(), "Overridden Name");
         assert_eq!(TestEnum::NameFullFormat.to_string(), "Unit: NameFullFormat");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //!
-//! enum-display is a crate for implementing [`std::fmt::Display`] on enum variants with macros.
+//! enum-display is a crate for implementing [`core::fmt::Display`] on enum variants with macros.
+//!
+//! This crate supports both `std` and `no_std` environments. In `no_std` mode, it works
+//! without allocation by writing directly to the formatter.
 //!
 //! # Simple Example
 //!
@@ -31,7 +34,25 @@
 //!     HelloGreeting { name: String },
 //! }
 //!
+//! # #[cfg(feature = "std")]
 //! assert_eq!(Message::HelloGreeting { name: "Alice".to_string() }.to_string(), "hello-greeting");
+//! ```
+//!
+//! # No-std Usage
+//!
+//! This crate works in `no_std` environments:
+//!
+//! ```rust
+//! # #![cfg_attr(not(feature = "std"), no_std)]
+//! use enum_display::EnumDisplay;
+//!
+//! #[derive(EnumDisplay)]
+//! enum Status {
+//!     Ready,
+//!
+//!     #[display("Error: {code}")]
+//!     Error { code: u32 },
+//! }
 //! ```
 //!
 //! # Example With Custom Variant Formatting
@@ -68,11 +89,23 @@
 //! assert_eq!(Conversation::HowOld(123).to_string(), "HowOld? 123");
 //! assert_eq!(Conversation::Wow.to_string(), "Wow!");
 //! ```
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub use enum_display_macro::*;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "std")]
+    use std::string::{String, ToString};
+
+    #[cfg(not(feature = "std"))]
+    extern crate alloc;
+
+    #[cfg(not(feature = "std"))]
+    use alloc::string::{String, ToString};
 
     #[allow(dead_code)]
     #[derive(EnumDisplay)]
@@ -135,7 +168,7 @@ mod tests {
     #[derive(EnumDisplay)]
     enum TestEnumWithLifetimeAndGenerics<'a, T: Clone>
     where
-        T: std::fmt::Display,
+        T: core::fmt::Display,
     {
         Name,
         Address {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,10 @@ mod tests {
 
     #[allow(dead_code)]
     #[derive(EnumDisplay)]
-    enum TestEnumWithGenerics<'a, T: Clone> where T: std::fmt::Display {
+    enum TestEnumWithGenerics<'a, T: Clone>
+    where
+        T: std::fmt::Display,
+    {
         Name,
         Address {
             street: &'a T,
@@ -150,8 +153,14 @@ mod tests {
     #[test]
     fn test_unnamed_fields_variant() {
         assert_eq!(TestEnum::DateOfBirth(1, 2, 1999).to_string(), "DateOfBirth");
-        assert_eq!(TestEnum::DateOfBirthPartialFormat(1, 2, 1999).to_string(), "Unnamed: DateOfBirthPartialFormat(1999)");
-        assert_eq!(TestEnum::DateOfBirthFullFormat(1, 2, 1999).to_string(), "Unnamed: DateOfBirthFullFormat(1, 2, 1999)");
+        assert_eq!(
+            TestEnum::DateOfBirthPartialFormat(1, 2, 1999).to_string(),
+            "Unnamed: DateOfBirthPartialFormat(1999)"
+        );
+        assert_eq!(
+            TestEnum::DateOfBirthFullFormat(1, 2, 1999).to_string(),
+            "Unnamed: DateOfBirthFullFormat(1, 2, 1999)"
+        );
     }
 
     #[test]
@@ -202,6 +211,9 @@ mod tests {
 
     #[test]
     fn test_unnamed_fields_variant_with_generics() {
-        assert_eq!(TestEnumWithGenerics::<'_, String>::DateOfBirth(1, 1, 2000).to_string(), "DateOfBirth");
+        assert_eq!(
+            TestEnumWithGenerics::<'_, String>::DateOfBirth(1, 1, 2000).to_string(),
+            "DateOfBirth"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,26 +34,26 @@
 //! assert_eq!(Message::HelloGreeting { name: "Alice".to_string() }.to_string(), "hello-greeting");
 //! ```
 //!
-//! # Example With Custom Formatting
+//! # Example With Custom Variant Formatting
 //!
-//! Display output can be customised with a format string passed to the `display` enum
+//! Display output can be customised using a format string passed to the `display` enum
 //! variant attribute.
 //!
-//! The case converted variant name is available via the `variant` named parameter.
+//! The case-converted variant name is always available via the `{variant}` named parameter.
 //!
-//! Additional parameters available to the format string depend on the type of enum variant:
+//! Additional parameters depend on the type of enum variant:
 //!
-//! | Variant Type     | Format String Field Access                                                        | Example                             |
-//! |------------------|-----------------------------------------------------------------------------------|-------------------------------------|
-//! | Named            | [Named Parameters](https://doc.rust-lang.org/std/fmt/#named-parameters)           | `"{variant} name field is: {name}"` |
-//! | Unnamed (tuple)  | [Positional Parameters](https://doc.rust-lang.org/std/fmt/#positional-parameters) | `"{variant} age field is: {0}"`     |
-//! | Unit             | No additional fields available                                                    | `"{variant} has no fields"`         |
+//! | Variant Type  | Format String Field Access                                                        | Example                             |
+//! |---------------|-----------------------------------------------------------------------------------|-------------------------------------|
+//! | Named {...}   | [Named Parameters](https://doc.rust-lang.org/std/fmt/#named-parameters)           | `"{variant} name field is: {name}"` |
+//! | Unnamed (...) | [Positional Parameters](https://doc.rust-lang.org/std/fmt/#positional-parameters) | `"{variant} age field is: {0}"`     |
+//! | Unit          | No additional fields available                                                    | `"{variant} has no fields"`         |
 //!
 //! ```rust
 //! use enum_display::EnumDisplay;
 //!
 //! #[derive(EnumDisplay)]
-//! enum Message {
+//! enum Conversation {
 //!     #[display("{variant} {name}!")]
 //!     Hello { name: String },
 //!
@@ -64,9 +64,9 @@
 //!     Wow,
 //! }
 //!
-//! assert_eq!(Message::Hello { name: "Alice".to_string() }.to_string(), "Hello Alice!");
-//! assert_eq!(Message::HowOld(123).to_string(), "HowOld? 123");
-//! assert_eq!(Message::Wow.to_string(), "Wow!");
+//! assert_eq!(Conversation::Hello { name: "Alice".to_string() }.to_string(), "Hello Alice!");
+//! assert_eq!(Conversation::HowOld(123).to_string(), "HowOld? 123");
+//! assert_eq!(Conversation::Wow.to_string(), "Wow!");
 //! ```
 pub use enum_display_macro::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,10 +45,10 @@ mod tests {
     enum TestEnum {
         Name,
 
-        #[display(format = "Overridden Name")]
-        OverrideName,
+        #[display("Overridden Name")]
+        OverriddenName,
 
-        #[display(format = "Unit: {variant}")]
+        #[display("Unit: {variant}")]
         NameFullFormat,
 
         Address {
@@ -58,7 +58,7 @@ mod tests {
             zip: String,
         },
 
-        #[display(format = "Named: {variant} {{{street}, {zip}}}")]
+        #[display("Named: {variant} {{{street}, {zip}}}")]
         AddressPartialFormat {
             street: String,
             city: String,
@@ -66,7 +66,7 @@ mod tests {
             zip: String,
         },
 
-        #[display(format = "Named: {variant} {{{street}, {city}, {state}, {zip}}}")]
+        #[display("Named: {variant} {{{street}, {city}, {state}, {zip}}}")]
         AddressFullFormat {
             street: String,
             city: String,
@@ -76,10 +76,10 @@ mod tests {
 
         DateOfBirth(u32, u32, u32),
 
-        #[display(format = "Unnamed: {variant}({2})")]
+        #[display("Unnamed: {variant}({2})")]
         DateOfBirthPartialFormat(u32, u32, u32),
 
-        #[display(format = "Unnamed: {variant}({0}, {1}, {2})")]
+        #[display("Unnamed: {variant}({0}, {1}, {2})")]
         DateOfBirthFullFormat(u32, u32, u32),
     }
 
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn test_unit_field_variant() {
         assert_eq!(TestEnum::Name.to_string(), "Name");
-        assert_eq!(TestEnum::OverrideName.to_string(), "Overridden Name");
+        assert_eq!(TestEnum::OverriddenName.to_string(), "Overridden Name");
         assert_eq!(TestEnum::NameFullFormat.to_string(), "Unit: NameFullFormat");
     }
 

--- a/tests/no_std_integration.rs
+++ b/tests/no_std_integration.rs
@@ -1,0 +1,161 @@
+#![no_std]
+
+extern crate alloc;
+use alloc::string::ToString;
+use enum_display::EnumDisplay;
+
+#[derive(EnumDisplay)]
+enum SimpleEnum {
+    Red,
+    Green,
+    Blue,
+}
+
+#[derive(EnumDisplay)]
+enum FormattedEnum {
+    #[display("Custom: {variant}")]
+    Format,
+
+    #[display("Value is {value}")]
+    Data { value: u32 },
+
+    #[display("Tuple: ({0}, {1})")]
+    Tuple(i32, i32),
+}
+
+#[derive(EnumDisplay)]
+#[enum_display(case = "Snake")]
+enum CaseTransformEnum {
+    CamelCase,
+    AnotherExample,
+    XmlHttpRequest,
+}
+
+#[derive(EnumDisplay)]
+enum ComplexEnum {
+    Unit,
+
+    Named {
+        _field1: u32,
+        _field2: alloc::string::String,
+    },
+
+    #[display("Complex: {variant} with {field1}")]
+    NamedFormat {
+        field1: u32,
+        field2: alloc::string::String,
+    },
+
+    #[allow(dead_code)]
+    Tuple(u32, alloc::string::String),
+
+    #[display("Tuple: ({0})")]
+    TupleFormat(u32),
+}
+
+#[test]
+fn test_simple_enum() {
+    assert_eq!(SimpleEnum::Red.to_string(), "Red");
+    assert_eq!(SimpleEnum::Green.to_string(), "Green");
+    assert_eq!(SimpleEnum::Blue.to_string(), "Blue");
+}
+
+#[test]
+fn test_formatted_enum() {
+    assert_eq!(FormattedEnum::Format.to_string(), "Custom: Format");
+    assert_eq!(FormattedEnum::Data { value: 42 }.to_string(), "Value is 42");
+    assert_eq!(FormattedEnum::Tuple(10, 20).to_string(), "Tuple: (10, 20)");
+}
+
+#[test]
+fn test_case_transform() {
+    assert_eq!(CaseTransformEnum::CamelCase.to_string(), "camel_case");
+    assert_eq!(
+        CaseTransformEnum::AnotherExample.to_string(),
+        "another_example"
+    );
+    assert_eq!(
+        CaseTransformEnum::XmlHttpRequest.to_string(),
+        "xml_http_request"
+    );
+}
+
+#[test]
+fn test_complex_enum() {
+    assert_eq!(ComplexEnum::Unit.to_string(), "Unit");
+
+    assert_eq!(
+        ComplexEnum::Named {
+            _field1: 123,
+            _field2: "test".into()
+        }
+        .to_string(),
+        "Named"
+    );
+
+    assert_eq!(
+        ComplexEnum::NamedFormat {
+            field1: 456,
+            field2: "ignored".into()
+        }
+        .to_string(),
+        "Complex: NamedFormat with 456"
+    );
+
+    assert_eq!(ComplexEnum::Tuple(789, "value".into()).to_string(), "Tuple");
+
+    assert_eq!(ComplexEnum::TupleFormat(999).to_string(), "Tuple: (999)");
+}
+
+#[test]
+fn test_core_fmt_usage() {
+    use core::fmt::Write;
+
+    let mut buffer = alloc::string::String::new();
+
+    // Test simple enum
+    write!(&mut buffer, "{}", SimpleEnum::Red).unwrap();
+    assert_eq!(buffer, "Red");
+
+    buffer.clear();
+
+    // Test formatted enum
+    write!(&mut buffer, "{}", FormattedEnum::Format).unwrap();
+    assert_eq!(buffer, "Custom: Format");
+
+    buffer.clear();
+
+    // Test case transform
+    write!(&mut buffer, "{}", CaseTransformEnum::CamelCase).unwrap();
+    assert_eq!(buffer, "camel_case");
+}
+
+// Test that Display trait is properly implemented
+#[test]
+fn test_display_trait() {
+    fn accepts_display<T: core::fmt::Display>(item: T) -> alloc::string::String {
+        alloc::format!("{item}")
+    }
+
+    assert_eq!(accepts_display(SimpleEnum::Red), "Red");
+    assert_eq!(accepts_display(FormattedEnum::Format), "Custom: Format");
+    assert_eq!(accepts_display(CaseTransformEnum::CamelCase), "camel_case");
+}
+
+// Test with generics
+#[derive(EnumDisplay)]
+enum GenericEnum<T: core::fmt::Display> {
+    Value(T),
+
+    #[display("Generic: {0}")]
+    FormattedValue(T),
+}
+
+#[test]
+fn test_generic_enum() {
+    assert_eq!(GenericEnum::Value(42u32).to_string(), "Value");
+    assert_eq!(
+        GenericEnum::FormattedValue(42u32).to_string(),
+        "Generic: 42"
+    );
+}


### PR DESCRIPTION
This is a considerable update of the proc macro which supports optional custom format strings per variant with full access to variant fields via the `#[variant_display(format = "xyz")]` attribute.

I recommend reading the code in isolation rather than as a diff.

# Summary
* Added `EnumAttrs` which handles parsing of the main `enum_display` attribute
* Added `VariantAttrs` which handles parsing of the new `variant_display` field attribute
* `variant_display` field attribute allows the user to customise each variant
  - The `format = "xyz"` argument defines a custom display format (see below for **Format Behaviour**) - if omitted, the original crate behaviour is used
* Introduced a new Intermediate Representation (IR) to hold variant info and allow for more complex processing:
  - `VariantInfo` holds properties common to all variant types
  - `NamedVariantIR`, `UnnamedVariantIR`, and `UnitVariantIR` are the intermediate representations of variant types
  - `VariantIR` wraps all of those
* Pipeline updated to account for new Intermediate Representation
  - Parsing of `syn` tokens is moved to the `from_*()` methods of `EnumAttrs`, `VariantAttrs`, and `VariantIR`
  - We detect if any variant specifies a "format" string - this is to ensure all match arms return the same type
  - Finally we generate match arm tokens with the `VariantIR::gen()` method
* Tests have been updated

# Format Behaviour
Format strings behave almost identically to using `format!()` in normal rust code so it should be very familiar to users. Besides a bit of translation of unnamed fields, the string specified by the user is the string that ends up as the parameter to `format!()` in each match arm.

The following considerations apply:
* To print the case adjusted variant name, you use the `{variant}` placeholder
* To print named variant fields, you use the field name placeholder, eg. if we have `Variant { my_field: u32 }`, you use the `{my_field}` placeholder
* To print unnamed variant fields, you use a numbered placeholder, eg. if we have `Variant(u32)`, you use the `{0}` placeholder (to access the first tuple element)
* It is not currently possible to access fields within fields - each field must implment its own Display or Debug
* Most of the common inline format specs are supported, eg. `{my_field:?}` displays `my_field` using its `Debug` implementation, `{0:5}` displays the first unnamed field with a width of 5 - however - format spec options which depend on extra arguments passed into `format!()` are not supported

# Additional Notes
* I haven't included any doc changes in this PR - if you like the PR, then I'll happily update the docs
* I've left it to the user to decide if their target platform supports `format!()` - perhaps instead, we should [extern alloc](https://stackoverflow.com/questions/71675411/refer-to-an-extern-crate-in-macro-expansion) and hide it behind a feature flag?
* This branch accidentally includes code from #4 as that was small and done in `main` - let me know if you want them separated. Otherwise merging #4 first or discarding and just merging this would also work.

# Full examples
```rust
#[derive(EnumDisplay)]
enum TestEnum {
    // Displayed as "Name"
    Name,

    // Displayed as "Unit: NameFullFormat"
    #[variant_display(format = "Unit: {variant}")]
    NameFullFormat,

    // Displayed as "Address"
    Address {
        street: String,
        city: String,
        state: String,
        zip: String,
    },

    // Displayed as "Named: AddressPartialFormat {123 Main St, 12345}"
    #[variant_display(format = "Named: {variant} {{{street}, {zip}}}")]
    AddressPartialFormat {
        street: String,
        city: String,
        state: String,
        zip: String,
    },

    // Displayed as "Named: AddressFullFormat {123 Main St, Any Town, CA, 12345}"
    #[variant_display(format = "Named: {variant} {{{street}, {city}, {state}, {zip}}}")]
    AddressFullFormat {
        street: String,
        city: String,
        state: String,
        zip: String,
    },

    // Displayed as "DateOfBirth"
    DateOfBirth(u32, u32, u32),

    // Displayed as "Unnamed: DateOfBirthPartialFormat(1999)"
    #[variant_display(format = "Unnamed: {variant}({2})")]
    DateOfBirthPartialFormat(u32, u32, u32),

    // Displayed as "Unnamed: DateOfBirthFullFormat(1, 2, 1999)"
    #[variant_display(format = "Unnamed: {variant}({0}, {1}, {2})")]
    DateOfBirthFullFormat(u32, u32, u32),
}

#[test]
fn test_unit_field_variant() {
    assert_eq!(TestEnum::Name.to_string(), "Name");
    assert_eq!(TestEnum::NameFullFormat.to_string(), "Unit: NameFullFormat");
}

#[test]
fn test_named_fields_variant() {
    assert_eq!(
        TestEnum::Address {
            street: "123 Main St".to_string(),
            city: "Any Town".to_string(),
            state: "CA".to_string(),
            zip: "12345".to_string()
        }
        .to_string(),
        "Address"
    );
    assert_eq!(
        TestEnum::AddressPartialFormat {
            street: "123 Main St".to_string(),
            city: "Any Town".to_string(),
            state: "CA".to_string(),
            zip: "12345".to_string()
        }
        .to_string(),
        "Named: AddressPartialFormat {123 Main St, 12345}"
    );
    assert_eq!(
        TestEnum::AddressFullFormat {
            street: "123 Main St".to_string(),
            city: "Any Town".to_string(),
            state: "CA".to_string(),
            zip: "12345".to_string()
        }
        .to_string(),
        "Named: AddressFullFormat {123 Main St, Any Town, CA, 12345}"
    );
}

#[test]
fn test_unnamed_fields_variant() {
    assert_eq!(TestEnum::DateOfBirth(1, 2, 1999).to_string(), "DateOfBirth");
    assert_eq!(TestEnum::DateOfBirthPartialFormat(1, 2, 1999).to_string(), "Unnamed: DateOfBirthPartialFormat(1999)");
    assert_eq!(TestEnum::DateOfBirthFullFormat(1, 2, 1999).to_string(), "Unnamed: DateOfBirthFullFormat(1, 2, 1999)");
}
```